### PR TITLE
Fix: Update GitHub Actions workflow for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,4 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+        run: npm run deploy


### PR DESCRIPTION
This commit modifies the `.github/workflows/deploy.yml` file to use the `npm run deploy` script for deploying the application to GitHub Pages.

The previous configuration used the `peaceiris/actions-gh-pages` action, which was redundant as the `deploy` script in `package.json` already handles the deployment using `gh-pages`.

This change ensures that the deployment process is streamlined and uses the defined script in `package.json`.